### PR TITLE
Fix en in LANGS, use %w so this won't be an issue in the future

### DIFF
--- a/lib/openweathermap/data/constants.rb
+++ b/lib/openweathermap/data/constants.rb
@@ -7,8 +7,7 @@ module OpenWeatherMap
     UNITS = [nil, 'metric', 'imperial']
 
     # Accepted locales
-    LANGS = ['ar', 'bg', 'ca', 'cz', 'de', 'el', 'fa', 'fi', 'fr', 'gl', 'hr', 'hu', 'it', 'ja', 'kr', 'la',
-      'lt', 'mk', 'nl', 'pl', 'pt', 'ro', 'ru', 'se', 'sk', 'sl', 'es', 'tr', 'ua', 'vi', 'zh_cn', 'zh_tw' 'en']
+    LANGS = %w(ar bg ca cz de el fa fi fr gl hr hu it ja kr la lt mk nl pl pt ro ru se sk sl es tr ua vi zh_cn zh_tw en)
 
     # The different URLs 
     URLS = {


### PR DESCRIPTION
the zh_tw and en language codes were being concatenated to zh_twen, making the default en (as well as zh_tw) an invalid language